### PR TITLE
docs: fix custom header example

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -622,8 +622,8 @@ Supported variable names are:
 
       route:
         cluster: www
-        request_headers_to_add:
-          - header:
-              key: "x-request-start"
-              value: "%START_TIME(%s.%3f)%"
-            append: true
+      request_headers_to_add:
+        - header:
+            key: "x-request-start"
+            value: "%START_TIME(%s.%3f)%"
+          append: true


### PR DESCRIPTION
The example shows the request_headers_to_add in the RouteAction, and this should be in the Route

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
